### PR TITLE
feat: Access Token 저장 방식 변경(localstorage -> cookie)

### DIFF
--- a/src/main/java/com/reboot/auth/config/SecurityConfig.java
+++ b/src/main/java/com/reboot/auth/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.reboot.auth.jwt.JwtTokenProvider;
 import com.reboot.auth.jwt.LoginFilter;
 import com.reboot.auth.repository.RefreshTokenRepository;
 import com.reboot.auth.service.RefreshTokenService;
+import com.reboot.auth.service.ReissueService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -28,13 +29,15 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final ReissueService reissueService;
 
-    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JwtTokenProvider jwtTokenProvider, RefreshTokenService refreshTokenService, RefreshTokenRepository refreshTokenRepository) {
+    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JwtTokenProvider jwtTokenProvider, RefreshTokenService refreshTokenService, RefreshTokenRepository refreshTokenRepository, ReissueService reissueService) {
 
         this.authenticationConfiguration = authenticationConfiguration;
         this.jwtTokenProvider = jwtTokenProvider;
         this.refreshTokenService = refreshTokenService;
         this.refreshTokenRepository = refreshTokenRepository;
+        this.reissueService = reissueService;
     }
 
     @Bean
@@ -63,7 +66,7 @@ public class SecurityConfig {
                         .anyRequest().permitAll());
 
         http
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), LoginFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, reissueService), LoginFilter.class)
                 .addFilterBefore(new CustomLogoutFilter(jwtTokenProvider, refreshTokenRepository), LogoutFilter.class);
 
         http

--- a/src/main/java/com/reboot/auth/controller/ReissueController.java
+++ b/src/main/java/com/reboot/auth/controller/ReissueController.java
@@ -3,7 +3,6 @@ package com.reboot.auth.controller;
 import com.reboot.auth.jwt.JwtTokenProvider;
 import com.reboot.auth.service.RefreshTokenService;
 import com.reboot.auth.service.ReissueService;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
@@ -11,9 +10,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-
-import java.time.Instant;
-import java.util.Date;
 
 @Controller
 @ResponseBody
@@ -47,14 +43,11 @@ public class ReissueController {
             refreshTokenService.deleteRefreshToken(token);
             refreshTokenService.addRefreshEntity(username, newRefresh);
 
-            response.setHeader(jwtTokenProvider.CATEGORY_ACCESS, newAccess);
+            response.addCookie(jwtTokenProvider.createCookie(jwtTokenProvider.CATEGORY_ACCESS, newAccess));
             response.addCookie(jwtTokenProvider.createCookie(jwtTokenProvider.CATEGORY_REFRESH, newRefresh));
             return new ResponseEntity<>(HttpStatus.OK);
         } catch (IllegalArgumentException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
         }
     }
-
-    // refresh token 추출
-
 }

--- a/src/main/java/com/reboot/auth/entity/Member.java
+++ b/src/main/java/com/reboot/auth/entity/Member.java
@@ -39,7 +39,4 @@ public class Member {
     @Column(name = "role")
     private String role;
 
-    //맞춤 강사 서비스
-    @Column(name = "matching_service")
-    private Boolean matchingService = false;
 }

--- a/src/main/java/com/reboot/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/reboot/auth/jwt/JwtAuthenticationFilter.java
@@ -1,7 +1,6 @@
 package com.reboot.auth.jwt;
 
 import com.reboot.auth.service.ReissueService;
-import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/reboot/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/reboot/auth/jwt/JwtAuthenticationFilter.java
@@ -19,7 +19,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain) throws ServletException, IOException {
-        String accessToken = req.getHeader(jwtTokenProvider.CATEGORY_ACCESS);
+        String accessToken = jwtTokenProvider.getTokenFromCookies(jwtTokenProvider.CATEGORY_ACCESS, req);
 
         if (accessToken == null) {
             chain.doFilter(req, res);

--- a/src/main/java/com/reboot/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/reboot/auth/jwt/JwtTokenProvider.java
@@ -4,6 +4,8 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.java.Log;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -53,6 +55,15 @@ public class JwtTokenProvider {
                 .expiration(expiration)
                 .signWith(getSecretKey(), Jwts.SIG.HS256)
                 .compact();
+    }
+
+    public Cookie createCookie(String key, String vaule) {
+        Cookie cookie = new Cookie(key, vaule);
+        cookie.setMaxAge((int)GetExpirationMs(key));
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        return cookie;
     }
 
     public String getCategory(String token) {
@@ -147,5 +158,17 @@ public class JwtTokenProvider {
         }
 
         return expirationMs;
+    }
+
+    public String getTokenFromCookies(String category, HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return null;
+
+        for (Cookie cookie : cookies) {
+            if (category.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/com/reboot/auth/jwt/LoginFilter.java
+++ b/src/main/java/com/reboot/auth/jwt/LoginFilter.java
@@ -56,13 +56,10 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String refreshToken = jwtTokenProvider.generateToken(jwtTokenProvider.CATEGORY_REFRESH, username, role);
 
         // Refresh Token DB 저장
-        Instant now = Instant.now();
-        Date expiration = new Date(now.toEpochMilli() + jwtTokenProvider.GetExpirationMs(jwtTokenProvider.CATEGORY_REFRESH));
-        String refresh_Expiration = expiration.toString();
-        refreshTokenService.addRefreshEntity(username, refreshToken, refresh_Expiration);
+        refreshTokenService.addRefreshEntity(username, refreshToken);
 
-        response.setHeader(jwtTokenProvider.CATEGORY_ACCESS, accessToken);
-        response.addCookie(refreshTokenService.createCookie(jwtTokenProvider.CATEGORY_REFRESH, refreshToken));
+        response.addCookie(jwtTokenProvider.createCookie(jwtTokenProvider.CATEGORY_ACCESS, accessToken));
+        response.addCookie(jwtTokenProvider.createCookie(jwtTokenProvider.CATEGORY_REFRESH, refreshToken));
         response.setStatus(HttpServletResponse.SC_OK);
     }
 

--- a/src/main/java/com/reboot/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/reboot/auth/service/RefreshTokenService.java
@@ -3,7 +3,6 @@ package com.reboot.auth.service;
 import com.reboot.auth.entity.RefreshToken;
 import com.reboot.auth.jwt.JwtTokenProvider;
 import com.reboot.auth.repository.RefreshTokenRepository;
-import jakarta.servlet.http.Cookie;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;

--- a/src/main/java/com/reboot/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/reboot/auth/service/RefreshTokenService.java
@@ -6,6 +6,9 @@ import com.reboot.auth.repository.RefreshTokenRepository;
 import jakarta.servlet.http.Cookie;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
+import java.util.Date;
+
 @Service
 public class RefreshTokenService {
 
@@ -17,11 +20,11 @@ public class RefreshTokenService {
         this.jwtTokenProvider = jwtTokenProvider;
     }
 
-    public void addRefreshEntity(String username, String token, String expiration){
+    public void addRefreshEntity(String username, String token){
         RefreshToken refreshToken = new RefreshToken();
         refreshToken.setUsername(username);
         refreshToken.setToken(token);
-        refreshToken.setExpiration(expiration);
+        refreshToken.setExpiration(getExpiration());
 
         refreshTokenRepository.save(refreshToken);
     }
@@ -30,10 +33,9 @@ public class RefreshTokenService {
         refreshTokenRepository.deleteByToken(token);
     }
 
-    public Cookie createCookie(String key, String vaule) {
-        Cookie cookie = new Cookie(key, vaule);
-        cookie.setMaxAge((int)jwtTokenProvider.GetExpirationMs(jwtTokenProvider.CATEGORY_REFRESH)); // refreshToken과 동일하게
-        cookie.setHttpOnly(true);
-        return cookie;
+    private String getExpiration(){
+        Instant now = Instant.now();
+        Date expiration = new Date(now.toEpochMilli() + jwtTokenProvider.GetExpirationMs(jwtTokenProvider.CATEGORY_REFRESH));
+        return expiration.toString();
     }
 }

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -235,24 +235,6 @@
 
         loginForm.addEventListener('submit', async function(e) {
             // 폼 검증이 필요한 경우 여기에 구현
-            e.preventDefault();
-
-            const formData = new FormData();
-            formData.append('username', username.value);
-            formData.append('password', password.value);
-
-            const response = await fetch('http://localhost:8080/login', {
-               method: 'POST',
-               body: formData
-            });
-            if(response.ok){
-                const token = response.headers.get("access");
-                localStorage.setItem('token', token);
-                window.location.href = "/"
-            }
-            else{
-                window.location.href = "/auth/login?error"
-            }
         });
     });
 </script>


### PR DESCRIPTION
로그인 후 jwt 토큰 방식을 localstorage에 저장하면 페이지 이동 간 인증 처리에 불편함이 있어 cookie에 저장하는걸로 변경했습니다.
![image](https://github.com/user-attachments/assets/1a7e3387-9290-45c1-a11e-0c6b83814fee)

<details>

<summary> localStorage외 Cookie 저장 방식 차이 </summary>

항목 | localStorage | cookie (HttpOnly, SameSite)
-- | -- | --
XSS 공격에 대한 노출 | 🔴 노출됨 (JS로 접근 가능) | 🟢 안전 (HttpOnly 설정 시 JS 접근 불가)
CSRF 공격에 대한 노출 | 🟢 안전 (쿠키 자동 전송 안 됨) | 🔴 노출됨 (자동 전송되므로 SameSite 필요)
전송 방식 | Authorization 헤더로 수동 전송 | 자동 전송 (Set-Cookie → 이후 자동 첨부)
브라우저 간 공유 | ❌ 안 됨 | ❌ 안 됨
만료 처리 | 직접 삭제해야 함 | 서버에서 Max-Age 또는 Expires로 제어 가능
사용자 인증 흐름 유지 | ❌ 새로고침, 탭 닫기 등 관리 필요 | 🟢 브라우저가 자동 유지
Secure, SameSite 설정 | ❌ 직접 불가 (브라우저 정책에 의존) | 🟢 가능 (Secure, SameSite, HttpOnly) 설정
프론트 코드 관리 | 🟢 쉽다 (localStorage.getItem(...)) | 🔴 JS 접근 불가 (쿠키 읽기 불가)

</details>

TODO.
~~Access Token 만료 시 자동 발급 구현~~(완료)
Oauth 인증으로 소셜 로그인 구현 (시간이 된다면...)