### PR TITLE
feat: 회원가입, 로그인 구현

### DIFF
--- a/src/main/java/com/reboot/auth/config/SecurityConfig.java
+++ b/src/main/java/com/reboot/auth/config/SecurityConfig.java
@@ -50,8 +50,9 @@ public class SecurityConfig {
         // 경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/","/login", "/sign").permitAll()
-                        .requestMatchers("/admin").hasRole("ADMIN")
+                        .requestMatchers("/","/auth/login", "/auth/sign").permitAll()
+                        // .requestMatchers("/admin").hasRole("ADMIN")
+                        .requestMatchers("/auth/reissue").permitAll()
                         .anyRequest().permitAll());
 
         http

--- a/src/main/java/com/reboot/auth/config/SecurityConfig.java
+++ b/src/main/java/com/reboot/auth/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.reboot.auth.jwt.JwtTokenProvider;
 import com.reboot.auth.jwt.LoginFilter;
 import com.reboot.auth.repository.RefreshTokenRepository;
 import com.reboot.auth.service.RefreshTokenService;
+import com.reboot.auth.service.ReissueService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -28,13 +29,15 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final ReissueService reissueService;
 
-    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JwtTokenProvider jwtTokenProvider, RefreshTokenService refreshTokenService, RefreshTokenRepository refreshTokenRepository) {
+    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JwtTokenProvider jwtTokenProvider, RefreshTokenService refreshTokenService, RefreshTokenRepository refreshTokenRepository, ReissueService reissueService) {
 
         this.authenticationConfiguration = authenticationConfiguration;
         this.jwtTokenProvider = jwtTokenProvider;
         this.refreshTokenService = refreshTokenService;
         this.refreshTokenRepository = refreshTokenRepository;
+        this.reissueService = reissueService;
     }
 
     @Bean
@@ -63,7 +66,7 @@ public class SecurityConfig {
                         .anyRequest().permitAll());
 
         http
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), LoginFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, reissueService), LoginFilter.class)
                 .addFilterBefore(new CustomLogoutFilter(jwtTokenProvider, refreshTokenRepository), LogoutFilter.class);
 
         http

--- a/src/main/java/com/reboot/auth/config/SecurityConfig.java
+++ b/src/main/java/com/reboot/auth/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.reboot.auth.config;
 import com.reboot.auth.jwt.JwtAuthenticationFilter;
 import com.reboot.auth.jwt.JwtTokenProvider;
 import com.reboot.auth.jwt.LoginFilter;
+import com.reboot.auth.service.RefreshTokenService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -22,11 +23,13 @@ public class SecurityConfig {
 
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
 
-    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JwtTokenProvider jwtTokenProvider) {
+    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JwtTokenProvider jwtTokenProvider, RefreshTokenService refreshTokenService) {
 
         this.authenticationConfiguration = authenticationConfiguration;
         this.jwtTokenProvider = jwtTokenProvider;
+        this.refreshTokenService = refreshTokenService;
     }
 
     @Bean
@@ -58,7 +61,7 @@ public class SecurityConfig {
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), LoginFilter.class);
 
         http
-                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtTokenProvider, refreshTokenService), UsernamePasswordAuthenticationFilter.class);
 
         http
                 .sessionManagement((session) ->

--- a/src/main/java/com/reboot/auth/config/SecurityConfig.java
+++ b/src/main/java/com/reboot/auth/config/SecurityConfig.java
@@ -50,9 +50,8 @@ public class SecurityConfig {
         // 경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/","/auth/login", "/auth/sign").permitAll()
+                        .requestMatchers("/","/auth/login", "/auth/sign", "/reissue").permitAll()
                         // .requestMatchers("/admin").hasRole("ADMIN")
-                        .requestMatchers("/auth/reissue").permitAll()
                         .anyRequest().permitAll());
 
         http

--- a/src/main/java/com/reboot/auth/config/SecurityConfig.java
+++ b/src/main/java/com/reboot/auth/config/SecurityConfig.java
@@ -1,8 +1,10 @@
 package com.reboot.auth.config;
 
+import com.reboot.auth.jwt.CustomLogoutFilter;
 import com.reboot.auth.jwt.JwtAuthenticationFilter;
 import com.reboot.auth.jwt.JwtTokenProvider;
 import com.reboot.auth.jwt.LoginFilter;
+import com.reboot.auth.repository.RefreshTokenRepository;
 import com.reboot.auth.service.RefreshTokenService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,6 +18,7 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -24,12 +27,14 @@ public class SecurityConfig {
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
+    private final RefreshTokenRepository refreshTokenRepository;
 
-    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JwtTokenProvider jwtTokenProvider, RefreshTokenService refreshTokenService) {
+    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JwtTokenProvider jwtTokenProvider, RefreshTokenService refreshTokenService, RefreshTokenRepository refreshTokenRepository) {
 
         this.authenticationConfiguration = authenticationConfiguration;
         this.jwtTokenProvider = jwtTokenProvider;
         this.refreshTokenService = refreshTokenService;
+        this.refreshTokenRepository = refreshTokenRepository;
     }
 
     @Bean
@@ -58,7 +63,8 @@ public class SecurityConfig {
                         .anyRequest().permitAll());
 
         http
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), LoginFilter.class);
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), LoginFilter.class)
+                .addFilterBefore(new CustomLogoutFilter(jwtTokenProvider, refreshTokenRepository), LogoutFilter.class);
 
         http
                 .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtTokenProvider, refreshTokenService), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/reboot/auth/controller/AuthController.java
+++ b/src/main/java/com/reboot/auth/controller/AuthController.java
@@ -2,8 +2,10 @@ package com.reboot.auth.controller;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
+@RequestMapping("/auth")
 public class AuthController {
 
     @GetMapping
@@ -13,16 +15,11 @@ public class AuthController {
 
     @GetMapping("/login")
     public String login() {
-        return "auth/login";
+        return "/auth/login";
     }
 
     @GetMapping("/sign")
     public String sign() {
-        return "auth/signup";
-    }
-
-    @GetMapping("/admin")
-    public String admin() {
-        return "auth/admin";
+        return "/auth/signup";
     }
 }

--- a/src/main/java/com/reboot/auth/controller/ReissueController.java
+++ b/src/main/java/com/reboot/auth/controller/ReissueController.java
@@ -1,0 +1,55 @@
+package com.reboot.auth.controller;
+
+import com.reboot.auth.service.ReissueService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@ResponseBody
+@RequestMapping("/auth")
+public class ReissueController {
+
+
+    private final ReissueService reissueService;
+
+    public ReissueController(ReissueService reissueService) {
+        this.reissueService = reissueService;
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
+        String token = extractRefreshTokenFromCookies(request);
+
+        if (token == null) {
+            return new ResponseEntity<>("refresh token null", HttpStatus.BAD_REQUEST);
+        }
+
+        try {
+            String newAccess = reissueService.reissueToken(token);
+            response.setHeader("access", newAccess);
+            return new ResponseEntity<>(HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    // refresh token 추출
+    private String extractRefreshTokenFromCookies(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return null;
+
+        for (Cookie cookie : cookies) {
+            if ("refresh".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/reboot/auth/controller/ReissueController.java
+++ b/src/main/java/com/reboot/auth/controller/ReissueController.java
@@ -3,7 +3,6 @@ package com.reboot.auth.controller;
 import com.reboot.auth.jwt.JwtTokenProvider;
 import com.reboot.auth.service.RefreshTokenService;
 import com.reboot.auth.service.ReissueService;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
@@ -11,9 +10,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-
-import java.time.Instant;
-import java.util.Date;
 
 @Controller
 @ResponseBody
@@ -47,14 +43,11 @@ public class ReissueController {
             refreshTokenService.deleteRefreshToken(token);
             refreshTokenService.addRefreshEntity(username, newRefresh);
 
-            response.setHeader(jwtTokenProvider.CATEGORY_ACCESS, newAccess);
+            response.addCookie(jwtTokenProvider.createCookie(jwtTokenProvider.CATEGORY_ACCESS, newAccess));
             response.addCookie(jwtTokenProvider.createCookie(jwtTokenProvider.CATEGORY_REFRESH, newRefresh));
             return new ResponseEntity<>(HttpStatus.OK);
         } catch (IllegalArgumentException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
         }
     }
-
-    // refresh token 추출
-
 }

--- a/src/main/java/com/reboot/auth/controller/SignupController.java
+++ b/src/main/java/com/reboot/auth/controller/SignupController.java
@@ -4,8 +4,10 @@ import com.reboot.auth.dto.SignupDTO;
 import com.reboot.auth.service.SignupService;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
+@RequestMapping("/auth")
 public class SignupController {
 
     private final SignupService signupService;
@@ -17,8 +19,8 @@ public class SignupController {
     @PostMapping("/sign")
     public String signupProcess(SignupDTO signupDTO) {
         if (signupService.signupProcess(signupDTO)) {
-            return "auth/login";
+            return "/auth/login";
         }
-        return "redirect:/sign";
+        return "redirect:/auth/sign";
     }
 }

--- a/src/main/java/com/reboot/auth/entity/Member.java
+++ b/src/main/java/com/reboot/auth/entity/Member.java
@@ -39,7 +39,4 @@ public class Member {
     @Column(name = "role")
     private String role;
 
-    //맞춤 강사 서비스
-    @Column(name = "matching_service")
-    private Boolean matchingService = false;
 }

--- a/src/main/java/com/reboot/auth/entity/RefreshToken.java
+++ b/src/main/java/com/reboot/auth/entity/RefreshToken.java
@@ -1,0 +1,22 @@
+package com.reboot.auth.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String token;
+
+    @Column(nullable = false)
+    private String expiration;
+}

--- a/src/main/java/com/reboot/auth/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/reboot/auth/jwt/CustomLogoutFilter.java
@@ -1,0 +1,91 @@
+package com.reboot.auth.jwt;
+
+import com.reboot.auth.repository.RefreshTokenRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+public class CustomLogoutFilter extends GenericFilterBean {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public CustomLogoutFilter(JwtTokenProvider jwtTokenProvider, RefreshTokenRepository refreshTokenRepository) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.refreshTokenRepository = refreshTokenRepository;
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        doFilter((HttpServletRequest) servletRequest, (HttpServletResponse)servletResponse, filterChain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+
+        if (!isLogoutRequest(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+            if (jwtTokenProvider.CATEGORY_REFRESH.equals(cookie.getName())) {
+                token = cookie.getValue();
+                break;
+            }
+        }
+
+        if (token == null) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        try {
+            jwtTokenProvider.validateToken(token);
+        } catch (ExpiredJwtException e) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        // 토큰이 refresh인지 확인
+        String category = jwtTokenProvider.getCategory(token);
+        if (!category.equals(jwtTokenProvider.CATEGORY_REFRESH)) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        //DB에 저장되어 있는지 확인
+        if (!refreshTokenRepository.existsByToken(token)) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        //로그아웃 진행
+        //Refresh 토큰 DB에서 제거
+        refreshTokenRepository.deleteByToken(token);
+
+        //Refresh 토큰 Cookie 값 0
+        Cookie cookie = new Cookie(jwtTokenProvider.CATEGORY_REFRESH, null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+
+        response.addCookie(cookie);
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+
+    private boolean isLogoutRequest(HttpServletRequest request) {
+        String requestUri = request.getRequestURI();
+        String requestMethod = request.getMethod();
+
+        return "/logout".equals(requestUri) && "POST".equals(requestMethod);
+    }
+}

--- a/src/main/java/com/reboot/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/reboot/auth/jwt/JwtAuthenticationFilter.java
@@ -1,7 +1,6 @@
 package com.reboot.auth.jwt;
 
 import com.reboot.auth.service.ReissueService;
-import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/reboot/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/reboot/auth/jwt/JwtAuthenticationFilter.java
@@ -19,7 +19,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain) throws ServletException, IOException {
-        String accessToken = req.getHeader("access");
+        String accessToken = req.getHeader(jwtTokenProvider.CATEGORY_ACCESS);
 
         if (accessToken == null) {
             chain.doFilter(req, res);
@@ -38,7 +38,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         String category = jwtTokenProvider.getCategory(accessToken);
-        if (!category.equals("access")) {
+        if (!category.equals(jwtTokenProvider.CATEGORY_ACCESS)) {
             PrintWriter writer = res.getWriter();
             writer.println("Invalid Access Token");
 

--- a/src/main/java/com/reboot/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/reboot/auth/jwt/JwtAuthenticationFilter.java
@@ -19,7 +19,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain) throws ServletException, IOException {
-        String accessToken = req.getHeader(jwtTokenProvider.CATEGORY_ACCESS);
+        String accessToken = jwtTokenProvider.getTokenFromCookies(jwtTokenProvider.CATEGORY_ACCESS, req);
 
         if (accessToken == null) {
             chain.doFilter(req, res);

--- a/src/main/java/com/reboot/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/reboot/auth/jwt/JwtTokenProvider.java
@@ -4,6 +4,8 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.java.Log;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -53,6 +55,15 @@ public class JwtTokenProvider {
                 .expiration(expiration)
                 .signWith(getSecretKey(), Jwts.SIG.HS256)
                 .compact();
+    }
+
+    public Cookie createCookie(String key, String vaule) {
+        Cookie cookie = new Cookie(key, vaule);
+        cookie.setMaxAge((int)GetExpirationMs(key));
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        return cookie;
     }
 
     public String getCategory(String token) {
@@ -147,5 +158,17 @@ public class JwtTokenProvider {
         }
 
         return expirationMs;
+    }
+
+    public String getTokenFromCookies(String category, HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return null;
+
+        for (Cookie cookie : cookies) {
+            if (category.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/com/reboot/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/reboot/auth/jwt/JwtTokenProvider.java
@@ -23,6 +23,9 @@ import java.util.List;
 @Log
 public class JwtTokenProvider {
 
+    public final String CATEGORY_ACCESS = "access";
+    public final String CATEGORY_REFRESH = "refresh";
+
     @Value("${jwt.secret}")
     private String secretKey;
     // @Value("${jwt.expiration-ms}")
@@ -130,10 +133,10 @@ public class JwtTokenProvider {
     private long SetExpirationMs(String category) {
         long expirationMs = 0L;
 
-        if(category.equals("access")) {
+        if(category.equals(CATEGORY_ACCESS)) {
             expirationMs = 600000; // 10분
         }
-        else if(category.equals("refresh")) {
+        else if(category.equals(CATEGORY_REFRESH)) {
             expirationMs = 86400000; // 1일
         }
 

--- a/src/main/java/com/reboot/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/reboot/auth/jwt/JwtTokenProvider.java
@@ -30,6 +30,10 @@ public class JwtTokenProvider {
     private String secretKey;
     // @Value("${jwt.expiration-ms}")
     // private long expirationMs;
+    @Value("${jwt.access-expiration-ms}")
+    private long accessExpirationMs;
+    @Value("${jwt.refresh-expiration-ms}")
+    private long refreshExpirationMs;
 
     public SecretKey getSecretKey() {
         return Keys.hmacShaKeyFor(secretKey.getBytes());
@@ -39,7 +43,7 @@ public class JwtTokenProvider {
     public String generateToken(String category, String username, String role) {
 
         Instant now = Instant.now();
-        Date expiration = new Date(now.toEpochMilli() + SetExpirationMs(category));
+        Date expiration = new Date(now.toEpochMilli() + GetExpirationMs(category));
 
         return Jwts.builder()
                 .claim("category", category)
@@ -130,14 +134,16 @@ public class JwtTokenProvider {
                 .getPayload();
     }
 
-    private long SetExpirationMs(String category) {
+    public long GetExpirationMs(String category) {
         long expirationMs = 0L;
 
         if(category.equals(CATEGORY_ACCESS)) {
-            expirationMs = 600000; // 10분
+            // expirationMs = 600000; // 10분
+            expirationMs = accessExpirationMs;
         }
         else if(category.equals(CATEGORY_REFRESH)) {
-            expirationMs = 86400000; // 1일
+            // expirationMs = 86400000; // 1일
+            expirationMs = refreshExpirationMs;
         }
 
         return expirationMs;

--- a/src/main/java/com/reboot/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/reboot/auth/jwt/JwtTokenProvider.java
@@ -52,7 +52,7 @@ public class JwtTokenProvider {
         try {
             return parseClaims(token).get("category", String.class);
         } catch (JwtException e) {
-            throw new BadCredentialsException("Invalid or expired JWT token", e);
+            throw new BadCredentialsException("Invalid Category JWT token", e);
         }
     }
 
@@ -60,7 +60,15 @@ public class JwtTokenProvider {
         try {
             return parseClaims(token).get("username", String.class);
         } catch (JwtException e) {
-            throw new BadCredentialsException("Invalid or expired JWT token", e);
+            throw new BadCredentialsException("Invalid Username JWT token", e);
+        }
+    }
+
+    public String getRole(String token) {
+        try {
+            return parseClaims(token).get("role", String.class);
+        } catch (JwtException e) {
+            throw new BadCredentialsException("Invalid Role JWT token", e);
         }
     }
 
@@ -81,7 +89,7 @@ public class JwtTokenProvider {
                         .toList();
             }
 
-            throw new BadCredentialsException("Invalid roles claim in JWT: unexpected type " + rolesObj.getClass());
+            throw new BadCredentialsException("Invalid roles claim in JWT: unexpected type " + rolesObj);
 
         } catch (JwtException e) {
             throw new BadCredentialsException("Failed to extract roles from token", e);

--- a/src/main/java/com/reboot/auth/jwt/LoginFilter.java
+++ b/src/main/java/com/reboot/auth/jwt/LoginFilter.java
@@ -56,13 +56,10 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String refreshToken = jwtTokenProvider.generateToken(jwtTokenProvider.CATEGORY_REFRESH, username, role);
 
         // Refresh Token DB 저장
-        Instant now = Instant.now();
-        Date expiration = new Date(now.toEpochMilli() + jwtTokenProvider.GetExpirationMs(jwtTokenProvider.CATEGORY_REFRESH));
-        String refresh_Expiration = expiration.toString();
-        refreshTokenService.addRefreshEntity(username, refreshToken, refresh_Expiration);
+        refreshTokenService.addRefreshEntity(username, refreshToken);
 
-        response.setHeader(jwtTokenProvider.CATEGORY_ACCESS, accessToken);
-        response.addCookie(refreshTokenService.createCookie(jwtTokenProvider.CATEGORY_REFRESH, refreshToken));
+        response.addCookie(jwtTokenProvider.createCookie(jwtTokenProvider.CATEGORY_ACCESS, accessToken));
+        response.addCookie(jwtTokenProvider.createCookie(jwtTokenProvider.CATEGORY_REFRESH, refreshToken));
         response.setStatus(HttpServletResponse.SC_OK);
     }
 

--- a/src/main/java/com/reboot/auth/jwt/LoginFilter.java
+++ b/src/main/java/com/reboot/auth/jwt/LoginFilter.java
@@ -11,7 +11,6 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 
@@ -49,11 +48,11 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         GrantedAuthority grantedAuthority = authorities.iterator().next();
         String role = grantedAuthority.getAuthority();
 
-        String accessToken = jwtTokenProvider.generateToken("access", username, role);
-        String refreshToken = jwtTokenProvider.generateToken("refresh", username, role);
+        String accessToken = jwtTokenProvider.generateToken(jwtTokenProvider.CATEGORY_ACCESS, username, role);
+        String refreshToken = jwtTokenProvider.generateToken(jwtTokenProvider.CATEGORY_REFRESH, username, role);
 
-        response.setHeader("access", accessToken);
-        response.addCookie(createCookie("refresh", refreshToken));
+        response.setHeader(jwtTokenProvider.CATEGORY_ACCESS, accessToken);
+        response.addCookie(createCookie(jwtTokenProvider.CATEGORY_REFRESH, refreshToken));
         response.setStatus(HttpServletResponse.SC_OK);
     }
 

--- a/src/main/java/com/reboot/auth/jwt/LoginFilter.java
+++ b/src/main/java/com/reboot/auth/jwt/LoginFilter.java
@@ -33,17 +33,17 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
 
-        //클라이언트 요청에서 username, password 추출
+        // 클라이언트 요청에서 username, password 추출
         String username = obtainUsername(request);
         String password = obtainPassword(request);
 
         UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password, null);
 
-        //token에 담은 검증을 위한 AuthenticationManager로 전달
+        // token에 담은 검증을 위한 AuthenticationManager로 전달
         return authenticationManager.authenticate(authToken);
     }
 
-    //로그인 성공 시 실행하는 메소드 (여기서 JWT를 발급)
+    // 로그인 성공 시 실행하는 메소드 (여기서 JWT를 발급)
     @Override
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws IOException {
         String username = authentication.getName();
@@ -63,15 +63,12 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         response.setHeader(jwtTokenProvider.CATEGORY_ACCESS, accessToken);
         response.addCookie(refreshTokenService.createCookie(jwtTokenProvider.CATEGORY_REFRESH, refreshToken));
-        response.sendRedirect("/"); // TODO. 프론트에서 상태값 보고 처리하도록
         response.setStatus(HttpServletResponse.SC_OK);
     }
 
-    //로그인 실패시 실행하는 메소드
+    // 로그인 실패시 실행하는 메소드
     @Override
     protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException {
-        response.sendRedirect("/auth/login?error"); // TODO. 프론트에서 상태값 보고 처리하도록
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
     }
-
 }

--- a/src/main/java/com/reboot/auth/jwt/LoginFilter.java
+++ b/src/main/java/com/reboot/auth/jwt/LoginFilter.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import java.io.IOException;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Date;
@@ -44,7 +45,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     //로그인 성공 시 실행하는 메소드 (여기서 JWT를 발급)
     @Override
-    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws IOException {
         String username = authentication.getName();
 
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
@@ -62,12 +63,14 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         response.setHeader(jwtTokenProvider.CATEGORY_ACCESS, accessToken);
         response.addCookie(refreshTokenService.createCookie(jwtTokenProvider.CATEGORY_REFRESH, refreshToken));
+        response.sendRedirect("/"); // TODO. 프론트에서 상태값 보고 처리하도록
         response.setStatus(HttpServletResponse.SC_OK);
     }
 
     //로그인 실패시 실행하는 메소드
     @Override
-    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException {
+        response.sendRedirect("/auth/login?error"); // TODO. 프론트에서 상태값 보고 처리하도록
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
     }
 

--- a/src/main/java/com/reboot/auth/jwt/LoginFilter.java
+++ b/src/main/java/com/reboot/auth/jwt/LoginFilter.java
@@ -60,12 +60,14 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         response.addCookie(jwtTokenProvider.createCookie(jwtTokenProvider.CATEGORY_ACCESS, accessToken));
         response.addCookie(jwtTokenProvider.createCookie(jwtTokenProvider.CATEGORY_REFRESH, refreshToken));
+        response.sendRedirect("/");
         response.setStatus(HttpServletResponse.SC_OK);
     }
 
     // 로그인 실패시 실행하는 메소드
     @Override
     protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException {
+        response.sendRedirect("/auth/login?error");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
     }
 }

--- a/src/main/java/com/reboot/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/reboot/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,16 @@
+package com.reboot.auth.repository;
+
+import com.reboot.auth.entity.RefreshToken;
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    boolean existsByToken(String token);
+
+    @Transactional
+    void deleteByToken(String token);
+
+}

--- a/src/main/java/com/reboot/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/reboot/auth/service/RefreshTokenService.java
@@ -3,7 +3,6 @@ package com.reboot.auth.service;
 import com.reboot.auth.entity.RefreshToken;
 import com.reboot.auth.jwt.JwtTokenProvider;
 import com.reboot.auth.repository.RefreshTokenRepository;
-import jakarta.servlet.http.Cookie;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;

--- a/src/main/java/com/reboot/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/reboot/auth/service/RefreshTokenService.java
@@ -6,6 +6,9 @@ import com.reboot.auth.repository.RefreshTokenRepository;
 import jakarta.servlet.http.Cookie;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
+import java.util.Date;
+
 @Service
 public class RefreshTokenService {
 
@@ -17,11 +20,11 @@ public class RefreshTokenService {
         this.jwtTokenProvider = jwtTokenProvider;
     }
 
-    public void addRefreshEntity(String username, String token, String expiration){
+    public void addRefreshEntity(String username, String token){
         RefreshToken refreshToken = new RefreshToken();
         refreshToken.setUsername(username);
         refreshToken.setToken(token);
-        refreshToken.setExpiration(expiration);
+        refreshToken.setExpiration(getExpiration());
 
         refreshTokenRepository.save(refreshToken);
     }
@@ -30,10 +33,9 @@ public class RefreshTokenService {
         refreshTokenRepository.deleteByToken(token);
     }
 
-    public Cookie createCookie(String key, String vaule) {
-        Cookie cookie = new Cookie(key, vaule);
-        cookie.setMaxAge((int)jwtTokenProvider.GetExpirationMs(jwtTokenProvider.CATEGORY_REFRESH)); // refreshToken과 동일하게
-        cookie.setHttpOnly(true);
-        return cookie;
+    private String getExpiration(){
+        Instant now = Instant.now();
+        Date expiration = new Date(now.toEpochMilli() + jwtTokenProvider.GetExpirationMs(jwtTokenProvider.CATEGORY_REFRESH));
+        return expiration.toString();
     }
 }

--- a/src/main/java/com/reboot/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/reboot/auth/service/RefreshTokenService.java
@@ -1,0 +1,39 @@
+package com.reboot.auth.service;
+
+import com.reboot.auth.entity.RefreshToken;
+import com.reboot.auth.jwt.JwtTokenProvider;
+import com.reboot.auth.repository.RefreshTokenRepository;
+import jakarta.servlet.http.Cookie;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public RefreshTokenService(RefreshTokenRepository refreshTokenRepository, JwtTokenProvider jwtTokenProvider) {
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    public void addRefreshEntity(String username, String token, String expiration){
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setUsername(username);
+        refreshToken.setToken(token);
+        refreshToken.setExpiration(expiration);
+
+        refreshTokenRepository.save(refreshToken);
+    }
+
+    public void deleteRefreshToken(String token){
+        refreshTokenRepository.deleteByToken(token);
+    }
+
+    public Cookie createCookie(String key, String vaule) {
+        Cookie cookie = new Cookie(key, vaule);
+        cookie.setMaxAge((int)jwtTokenProvider.GetExpirationMs(jwtTokenProvider.CATEGORY_REFRESH)); // refreshToken과 동일하게
+        cookie.setHttpOnly(true);
+        return cookie;
+    }
+}

--- a/src/main/java/com/reboot/auth/service/ReissueService.java
+++ b/src/main/java/com/reboot/auth/service/ReissueService.java
@@ -1,0 +1,36 @@
+package com.reboot.auth.service;
+
+import com.reboot.auth.jwt.JwtTokenProvider;
+import io.jsonwebtoken.ExpiredJwtException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReissueService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+
+    public ReissueService(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    public String reissueToken(String token) {
+        try {
+            jwtTokenProvider.validateToken(token);
+        } catch (ExpiredJwtException e) {
+            throw new IllegalArgumentException("refresh token expired");
+        }
+
+
+        String category = jwtTokenProvider.getCategory(token);
+        if (!"refresh".equals(category)) {
+            throw new IllegalArgumentException("invalid refresh token");
+        }
+
+        String username = jwtTokenProvider.getUsername(token);
+        String role = jwtTokenProvider.getRole(token);
+
+        // 새 access 토큰 발급
+        return jwtTokenProvider.generateToken("access", username, role);
+    }
+}

--- a/src/main/java/com/reboot/auth/service/ReissueService.java
+++ b/src/main/java/com/reboot/auth/service/ReissueService.java
@@ -14,7 +14,7 @@ public class ReissueService {
         this.jwtTokenProvider = jwtTokenProvider;
     }
 
-    public String reissueToken(String token) {
+    public String reissueAccessToken(String token) {
         try {
             jwtTokenProvider.validateToken(token);
         } catch (ExpiredJwtException e) {
@@ -31,6 +31,12 @@ public class ReissueService {
         String role = jwtTokenProvider.getRole(token);
 
         // 새 access 토큰 발급
-        return jwtTokenProvider.generateToken("access", username, role);
+        return jwtTokenProvider.generateToken(jwtTokenProvider.CATEGORY_ACCESS, username, role);
+    }
+
+    public String reissueRefreshToken(String token) {
+        String username = jwtTokenProvider.getUsername(token);
+        String role = jwtTokenProvider.getRole(token);
+        return jwtTokenProvider.generateToken(jwtTokenProvider.CATEGORY_REFRESH, username, role);
     }
 }

--- a/src/main/java/com/reboot/auth/service/ReissueService.java
+++ b/src/main/java/com/reboot/auth/service/ReissueService.java
@@ -23,7 +23,7 @@ public class ReissueService {
 
 
         String category = jwtTokenProvider.getCategory(token);
-        if (!"refresh".equals(category)) {
+        if (!jwtTokenProvider.CATEGORY_REFRESH.equals(category)) {
             throw new IllegalArgumentException("invalid refresh token");
         }
 

--- a/src/main/java/com/reboot/auth/service/SignupService.java
+++ b/src/main/java/com/reboot/auth/service/SignupService.java
@@ -39,7 +39,7 @@ public class SignupService {
         member.setName(dto.name());
         member.setEmail(dto.email());
         member.setNickname(dto.nickname());
-        member.setRole("ADMIN");
+        member.setRole("USER");
         return member;
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -56,7 +56,9 @@ spring:
 jwt:
   # openssl rand -base64 32
   secret: ${JWT_SECRET}
-  expiration-ms: ${JWT_EXPIRATION_MS} # 1시간
+  expiration-ms: ${JWT_EXPIRATION_MS} # 1시간 (미사용)
+  access-expiration-ms: ${JWT_ACCESS_EXPIRATION_MS} # 600000 (10분)
+  refresh-expiration-ms: ${JWT_REFRESH_EXPIRATION_MS} # 86400000 (1일)
 
 # Swagger
 # 여러 가지 설정 on-off 및 dev, prod 분기

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -70,8 +70,8 @@
                     <i class="ri-search-line"></i>
                 </div>
             </div>
-            <a th:href="@{/login}" class="bg-primary text-white border border-primary hover:bg-primary/90 px-4 py-2 !rounded-button text-sm font-medium whitespace-nowrap">로그인</a>
-            <a th:href="@{/sign}" class="bg-white text-primary border border-primary hover:bg-gray-50 px-4 py-2 !rounded-button text-sm font-medium whitespace-nowrap">회원가입</a>
+            <a th:href="@{/auth/login}" class="bg-primary text-white border border-primary hover:bg-primary/90 px-4 py-2 !rounded-button text-sm font-medium whitespace-nowrap">로그인</a>
+            <a th:href="@{/auth/sign}" class="bg-white text-primary border border-primary hover:bg-gray-50 px-4 py-2 !rounded-button text-sm font-medium whitespace-nowrap">회원가입</a>
             <button class="md:hidden w-10 h-10 flex items-center justify-center">
                 <i class="ri-menu-line text-xl"></i>
             </button>
@@ -188,7 +188,7 @@
         <!-- 회원가입 안내 -->
         <div class="text-center">
             <p class="text-sm text-gray-600">
-                아직 회원이 아니신가요? <a th:href="@{/sign}" class="font-medium text-primary hover:text-primary/80">회원가입</a>
+                아직 회원이 아니신가요? <a th:href="@{/auth/sign}" class="font-medium text-primary hover:text-primary/80">회원가입</a>
             </p>
         </div>
     </div>

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -231,9 +231,28 @@
 
         // 로그인 폼 제출
         const loginForm = document.querySelector('form');
+        const username = document.getElementById('username');
 
-        loginForm.addEventListener('submit', function(e) {
+        loginForm.addEventListener('submit', async function(e) {
             // 폼 검증이 필요한 경우 여기에 구현
+            e.preventDefault();
+
+            const formData = new FormData();
+            formData.append('username', username.value);
+            formData.append('password', password.value);
+
+            const response = await fetch('http://localhost:8080/login', {
+               method: 'POST',
+               body: formData
+            });
+            if(response.ok){
+                const token = response.headers.get("access");
+                localStorage.setItem('token', token);
+                window.location.href = "/"
+            }
+            else{
+                window.location.href = "/auth/login?error"
+            }
         });
     });
 </script>

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -235,24 +235,6 @@
 
         loginForm.addEventListener('submit', async function(e) {
             // 폼 검증이 필요한 경우 여기에 구현
-            e.preventDefault();
-
-            const formData = new FormData();
-            formData.append('username', username.value);
-            formData.append('password', password.value);
-
-            const response = await fetch('http://localhost:8080/login', {
-               method: 'POST',
-               body: formData
-            });
-            if(response.ok){
-                const token = response.headers.get("access");
-                localStorage.setItem('token', token);
-                window.location.href = "/"
-            }
-            else{
-                window.location.href = "/auth/login?error"
-            }
         });
     });
 </script>

--- a/src/main/resources/templates/auth/signup.html
+++ b/src/main/resources/templates/auth/signup.html
@@ -73,8 +73,8 @@
                     <i class="ri-search-line"></i>
                 </div>
             </div>
-            <a th:href="@{/login}" class="bg-primary text-white border border-primary hover:bg-primary/90 px-4 py-2 !rounded-button text-sm font-medium whitespace-nowrap">로그인</a>
-            <a th:href="@{/sign}" class="bg-white text-primary border border-primary hover:bg-gray-50 px-4 py-2 !rounded-button text-sm font-medium whitespace-nowrap">회원가입</a>
+            <a th:href="@{/auth/login}" class="bg-primary text-white border border-primary hover:bg-primary/90 px-4 py-2 !rounded-button text-sm font-medium whitespace-nowrap">로그인</a>
+            <a th:href="@{/auth/sign}" class="bg-white text-primary border border-primary hover:bg-gray-50 px-4 py-2 !rounded-button text-sm font-medium whitespace-nowrap">회원가입</a>
             <button class="md:hidden w-10 h-10 flex items-center justify-center">
                 <i class="ri-menu-line text-xl"></i>
             </button>
@@ -107,7 +107,7 @@
 
         <!-- 회원가입 폼 -->
         <div class="bg-white shadow-sm rounded-lg p-8 mb-6">
-            <form th:action="@{/sign}" method="post" class="space-y-5">
+            <form th:action="@{/auth/sign}" method="post" class="space-y-5">
                 <div>
                     <label for="username" class="block text-sm font-medium text-gray-700 mb-1">아이디</label>
                     <div class="relative">
@@ -271,7 +271,7 @@
         <!-- 로그인 안내 -->
         <div class="text-center">
             <p class="text-sm text-gray-600">
-                이미 계정이 있으신가요? <a th:href="@{/login}" class="font-medium text-primary hover:text-primary/80">로그인</a>
+                이미 계정이 있으신가요? <a th:href="@{/auth/login}" class="font-medium text-primary hover:text-primary/80">로그인</a>
             </p>
         </div>
     </div>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 메인 페이지
-<a href="/login">로그인 페이지</a>
-<a href="/sign">회원가입 페이지</a>
+<a href="/auth/login">로그인 페이지</a>
+<a href="/auth/sign">회원가입 페이지</a>
 </body>
 </html>


### PR DESCRIPTION
회원가입
Get : /sign -> /auth/sign
Post : /sign -> /auth/sign

로그인
Get : /login -> /auth/login
Post : /login 그대로 (Spring Security 자체 Post 주소사용)

로그아웃 (발급된 쿠키들은 삭제)
Post : /logout

jwt 토큰은 쿠키에 저장되는 방식
Access Token 유지 : 10분
Refresh Token 유지 : 1일 (DB 저장하여 관리)

로그인하면 쿠키에 저장되는데 브라우저를 닫고 다시 열어도 유지됩니다. 
(AccessToken은 만료되어도 Refresh Token이 만료안되면 자동 갱신)

TODO.
Refresh Token 만료 시 로그인 페이지로 전환 필요 (현재는 401 리턴)
회원 가입 시 비밀번호 유효성 검증 필요

