### PR TITLE
feat: Entity 수정

### DIFF
--- a/src/main/java/com/reboot/auth/entity/Game.java
+++ b/src/main/java/com/reboot/auth/entity/Game.java
@@ -4,24 +4,20 @@ import jakarta.persistence.*;
 import lombok.Data;
 
 @Entity
-@Table(name = "game")
 @Data
 public class Game {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "game_id")
     private Long gameId;
 
-    @ManyToOne
-    @JoinColumn(name = "member_id")
+    @OneToOne
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @Column(name = "game_type")
     private String gameType;
 
-    @Column(name = "game_tier")
     private String gameTier;
 
-    @Column(name = "game_position")
     private String gamePosition;
 }

--- a/src/main/java/com/reboot/auth/entity/Instructor.java
+++ b/src/main/java/com/reboot/auth/entity/Instructor.java
@@ -3,32 +3,32 @@ package com.reboot.auth.entity;
 import jakarta.persistence.*;
 import lombok.Data;
 
+import java.time.LocalDateTime;
+
 @Entity
-@Table(name = "instructor")
 @Data
 public class Instructor {
 
     @Id
-    @Column(name = "instructor_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long instructorId;
 
     @OneToOne
-    @JoinColumn(name = "instructor_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @Column(name = "member_id", insertable = false, updatable = false)
-    private Long memberId;
 
-    // 강사정보
     @Column(length = 1000)
     private String career;
 
     @Column(length = 2000)
     private String description;
 
-    @Column(name = "review_num")
-    private int reviewNum = 0;
+    private int reviewNum;
 
-    @Column(name = "rating")
-    private double rating = 0.0;
+    private double averageRating;
+
+    private LocalDateTime createdAt;
+
+    private Integer totalMembers;
 }

--- a/src/main/java/com/reboot/auth/entity/Member.java
+++ b/src/main/java/com/reboot/auth/entity/Member.java
@@ -3,43 +3,38 @@ package com.reboot.auth.entity;
 import jakarta.persistence.*;
 import lombok.Data;
 
-
 @Entity
-@Table(name = "member")
 @Data
 public class Member {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "member_id")
     private Long memberId;
 
-    //인증관련
     @Column(nullable = false, unique = true)
     private String username;
 
     @Column(nullable = false)
     private String password;
 
-    //기본정보
     @Column(nullable = false)
     private String name;
 
-    @Column(name ="e_mail",nullable = false, unique = true)
+    @Column(nullable = false, unique = true)
     private String email;
 
-    @Column(unique = true, nullable = false)
+    @Column(nullable = false, unique = true)
     private String nickname;
 
-    @Column(name = "profile_image")
     private String profileImage;
 
     private String phone;
 
-    @Column(name = "role")
     private String role;
 
-    //맞춤 강사 서비스
-    @Column(name = "matching_service")
-    private Boolean matchingService = false;
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL)
+    private Game game;
+
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL)
+    private Instructor instructor;
 }


### PR DESCRIPTION
Entity 수정 (https://www.notion.so/ERD-1e33550b7b5580d58bc0f07c3df08632?pvs=25) 
- Member
- Instructor
- Game

[ERD 수정]
추가 필드의 expertiseGameTypes, expertisePositions -> Auth 의 Game 엔터티 공유로 대체
Instructor 의 기본정보는 Member와  공유
Instructor 의 isActive, deleteAt 삭제

**Member와 Game은 OneToOne으로 변경했습니다**

_Colum Name은 따로 지정 안해도 알아서 스케이크 케이스로 생성되네요_


