### PR TITLE
feat : 강사 전용 마이페이지 구현

### DIFF
--- a/src/main/java/com/reboot/auth/controller/InstructorMypageController.java
+++ b/src/main/java/com/reboot/auth/controller/InstructorMypageController.java
@@ -2,6 +2,7 @@ package com.reboot.auth.controller;
 
 import com.reboot.auth.entity.Instructor;
 import com.reboot.auth.service.InstructorMypageService;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import java.security.Principal;
 
 @Controller
-@RequestMapping("/instructor/mypage")
+@RequestMapping("/mypage")
 public class InstructorMypageController {
     private final InstructorMypageService instructorMypageService;
 
@@ -18,11 +19,15 @@ public class InstructorMypageController {
         this.instructorMypageService = instructorMypageService;
     }
 
-    @GetMapping
-    public String instructorMypage(Principal principal, Model model) {
-        // 강사 인증 확인
+    @GetMapping("/instructorMypage")
+    public String instructorMyPage(Principal principal, HttpServletRequest request, Model model) {
+        if (principal == null) {
+            return "redirect:/auth/login";
+        }
+
+        // 강사가 아닌 경우 일반 마이페이지로 리다이렉트
         if (!instructorMypageService.isInstructor(principal.getName())) {
-            return "redirect:/mypage?error=require-instructor-auth";
+            return "redirect:/mypage";
         }
 
         Instructor instructor = instructorMypageService.getInstructor(principal.getName());

--- a/src/main/java/com/reboot/auth/controller/InstructorMypageController.java
+++ b/src/main/java/com/reboot/auth/controller/InstructorMypageController.java
@@ -1,0 +1,35 @@
+package com.reboot.auth.controller;
+
+import com.reboot.auth.entity.Instructor;
+import com.reboot.auth.service.InstructorMypageService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.security.Principal;
+
+@Controller
+@RequestMapping("/instructor/mypage")
+public class InstructorMypageController {
+    private final InstructorMypageService instructorMypageService;
+
+    public InstructorMypageController(InstructorMypageService instructorMypageService) {
+        this.instructorMypageService = instructorMypageService;
+    }
+
+    @GetMapping
+    public String instructorMypage(Principal principal, Model model) {
+        // 강사 인증 확인
+        if (!instructorMypageService.isInstructor(principal.getName())) {
+            return "redirect:/mypage?error=require-instructor-auth";
+        }
+
+        Instructor instructor = instructorMypageService.getInstructor(principal.getName());
+
+        model.addAttribute("instructor", instructor);
+        model.addAttribute("member", instructor.getMember());
+
+        return "mypage/instructorMypage";
+    }
+}

--- a/src/main/java/com/reboot/auth/controller/MypageController.java
+++ b/src/main/java/com/reboot/auth/controller/MypageController.java
@@ -62,6 +62,10 @@ public class MypageController {
         List<Payment> completedPayments = mypageService.getCompletedPayments(principal.getName());
         model.addAttribute("completedPayments", completedPayments);
 
+        // 강사 인증 확인
+        boolean isInstructor = mypageService.isInstructor(principal.getName());
+        model.addAttribute("isInstructor", isInstructor);
+
         return "mypage/index";
     }
 
@@ -211,6 +215,17 @@ public class MypageController {
             return "mypage/reservation-detail";
         } else {
             return "redirect:/mypage/reservations";
+        }
+    }
+
+    // 강사 페이지 버튼 클릭 처리
+    @GetMapping("/instructor-check")
+    public String checkInstructor(Principal principal, RedirectAttributes redirectAttributes) {
+        if (mypageService.isInstructor(principal.getName())) {
+            return "redirect:/mypage/instructorMypage";
+        } else {
+            redirectAttributes.addFlashAttribute("error", "강사 인증이 필요합니다. 강사 인증을 먼저 완료해주세요.");
+            return "redirect:/mypage";
         }
     }
 }

--- a/src/main/java/com/reboot/auth/controller/MypageController.java
+++ b/src/main/java/com/reboot/auth/controller/MypageController.java
@@ -8,6 +8,7 @@ import com.reboot.auth.repository.GameRepository;
 import com.reboot.auth.repository.MemberRepository;
 import com.reboot.auth.repository.ReservationMyRepository;
 import com.reboot.auth.service.MypageService;
+import com.reboot.payment.entity.Payment;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -56,6 +57,10 @@ public class MypageController {
         model.addAttribute("member", member);
         model.addAttribute("games", games);
         model.addAttribute("reservations", reservationMIES);
+
+        // 결제 완료된 강의 목록 추가
+        List<Payment> completedPayments = mypageService.getCompletedPayments(principal.getName());
+        model.addAttribute("completedPayments", completedPayments);
 
         return "mypage/index";
     }

--- a/src/main/java/com/reboot/auth/controller/MypageController.java
+++ b/src/main/java/com/reboot/auth/controller/MypageController.java
@@ -49,17 +49,20 @@ public class MypageController {
             return "redirect:/auth/login";  // 로그인 페이지로 리다이렉트
         }
 
+        // 강사인 경우 강사 페이지로 자동 리다이렉트
+        if (mypageService.isInstructor(principal.getName())) {
+            return "redirect:/mypage/instructorMypage";
+        }
+
         // 로그인 사용자 정보 조회
         Member member = mypageService.getCurrentMember(principal.getName());
         List<Game> games = gameRepository.findByMember_MemberId(member.getMemberId());//수정
         List<ReservationMy> reservationMIES = reservationRepository.findByMemberId(member.getMemberId());
+        List<Payment> completedPayments = mypageService.getCompletedPayments(principal.getName());
 
         model.addAttribute("member", member);
         model.addAttribute("games", games);
         model.addAttribute("reservations", reservationMIES);
-
-        // 결제 완료된 강의 목록 추가
-        List<Payment> completedPayments = mypageService.getCompletedPayments(principal.getName());
         model.addAttribute("completedPayments", completedPayments);
 
         // 강사 인증 확인
@@ -215,17 +218,6 @@ public class MypageController {
             return "mypage/reservation-detail";
         } else {
             return "redirect:/mypage/reservations";
-        }
-    }
-
-    // 강사 페이지 버튼 클릭 처리
-    @GetMapping("/instructor-check")
-    public String checkInstructor(Principal principal, RedirectAttributes redirectAttributes) {
-        if (mypageService.isInstructor(principal.getName())) {
-            return "redirect:/mypage/instructorMypage";
-        } else {
-            redirectAttributes.addFlashAttribute("error", "강사 인증이 필요합니다. 강사 인증을 먼저 완료해주세요.");
-            return "redirect:/mypage";
         }
     }
 }

--- a/src/main/java/com/reboot/auth/repository/InstructorRepository.java
+++ b/src/main/java/com/reboot/auth/repository/InstructorRepository.java
@@ -1,6 +1,7 @@
 package com.reboot.auth.repository;
 
 import com.reboot.auth.entity.Instructor;
+import com.reboot.auth.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,6 +15,12 @@ import java.util.Optional;
 // 강사 엔티티에 접근하기 위한 레포지토리 인터페이스
 @Repository
 public interface InstructorRepository extends JpaRepository<Instructor, Long> {
+
+    // Member 엔티티로 강사 존재 여부 확인
+    boolean existsByMember(Member member);
+
+    // Member 엔티티로 강사 정보 조회
+    Optional<Instructor> findByMember(Member member);
 
     // 사용자 ID로 강사 정보 조회
     Optional<Instructor> findByMember_MemberId(Long MemberId);

--- a/src/main/java/com/reboot/auth/service/InstructorMypageService.java
+++ b/src/main/java/com/reboot/auth/service/InstructorMypageService.java
@@ -1,0 +1,32 @@
+package com.reboot.auth.service;
+
+import com.reboot.auth.entity.Instructor;
+import com.reboot.auth.entity.Member;
+import com.reboot.auth.repository.InstructorRepository;
+import com.reboot.auth.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class InstructorMypageService {
+
+    private final InstructorRepository instructorRepository;
+    private final MemberRepository memberRepository;
+
+    public InstructorMypageService(InstructorRepository instructorRepository, MemberRepository memberRepository) {
+        this.instructorRepository = instructorRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    public boolean isInstructor(String username) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+        return instructorRepository.existsByMember(member);
+    }
+
+    public Instructor getInstructor(String username) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+        return instructorRepository.findByMember(member)
+                .orElseThrow(() -> new RuntimeException("강사 정보를 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/reboot/auth/service/MypageService.java
+++ b/src/main/java/com/reboot/auth/service/MypageService.java
@@ -4,12 +4,16 @@ import com.reboot.auth.dto.ProfileDTO;
 import com.reboot.auth.entity.Member;
 import com.reboot.auth.repository.MemberRepository;
 import com.reboot.auth.repository.ReservationMyRepository;
+import com.reboot.payment.entity.Payment;
+import com.reboot.payment.repository.PaymentRepository;
 import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 
 @Service
 public class MypageService {
@@ -90,5 +94,14 @@ public class MypageService {
         memberRepository.save(member);
 
         return true;
+    }
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    // 결제 완료된 강의 목록 조회
+    public List<Payment> getCompletedPayments(String username) {
+        Member member = getCurrentMember(username);
+        return paymentRepository.findCompletedPaymentsByMember(member.getMemberId());
     }
 }

--- a/src/main/java/com/reboot/auth/service/MypageService.java
+++ b/src/main/java/com/reboot/auth/service/MypageService.java
@@ -110,8 +110,7 @@ public class MypageService {
     // 강사 인증 확인
     public boolean isInstructor(String username) {
         Member member = getCurrentMember(username);
-        // Member에 연결된 Instructor가 있는지 확인
-        return instructorRepository.existsByMember(member);
+        return "INSTRUCTOR".equals(member.getRole());
     }
 
     public Instructor getInstructorByMember(String username) {

--- a/src/main/java/com/reboot/auth/service/MypageService.java
+++ b/src/main/java/com/reboot/auth/service/MypageService.java
@@ -1,7 +1,9 @@
 package com.reboot.auth.service;
 
 import com.reboot.auth.dto.ProfileDTO;
+import com.reboot.auth.entity.Instructor;
 import com.reboot.auth.entity.Member;
+import com.reboot.auth.repository.InstructorRepository;
 import com.reboot.auth.repository.MemberRepository;
 import com.reboot.auth.repository.ReservationMyRepository;
 import com.reboot.payment.entity.Payment;
@@ -104,4 +106,20 @@ public class MypageService {
         Member member = getCurrentMember(username);
         return paymentRepository.findCompletedPaymentsByMember(member.getMemberId());
     }
+
+    // 강사 인증 확인
+    public boolean isInstructor(String username) {
+        Member member = getCurrentMember(username);
+        // Member에 연결된 Instructor가 있는지 확인
+        return instructorRepository.existsByMember(member);
+    }
+
+    public Instructor getInstructorByMember(String username) {
+        Member member = getCurrentMember(username);
+        return instructorRepository.findByMember(member)
+                .orElseThrow(() -> new RuntimeException("강사 정보를 찾을 수 없습니다."));
+    }
+
+    @Autowired
+    private InstructorRepository instructorRepository;
 }

--- a/src/main/java/com/reboot/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/reboot/payment/repository/PaymentRepository.java
@@ -2,9 +2,15 @@ package com.reboot.payment.repository;
 
 import com.reboot.payment.entity.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
     Optional<Payment> findById(Long paymentId); // 단일 객체 반환
+
+    // Mypage용 조회쿼리 (결제완료 목록)
+    List<Payment> findCompletedPaymentsByMember(@Param("memberId") Long memberId);
+
 }

--- a/src/main/resources/templates/mypage/index.html
+++ b/src/main/resources/templates/mypage/index.html
@@ -9,6 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap" rel="stylesheet">
     <style>
         body {
             font-family: 'Noto Sans KR', sans-serif;
@@ -26,7 +27,7 @@
 <!-- 헤더 -->
 <header class="bg-white shadow">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
-        <h1 class="text-2xl font-bold text-gray-800">게임 코칭 매칭 플랫폼</h1>
+        <a href="/" class="text-2xl font-['Pacifico'] text-primary">Re:Boot</a>
         <nav>
             <ul class="flex space-x-4">
                 <li><a href="/" class="text-gray-600 hover:text-primary">홈</a></li>

--- a/src/main/resources/templates/mypage/index.html
+++ b/src/main/resources/templates/mypage/index.html
@@ -78,6 +78,10 @@
 
                 <div class="mt-6 flex flex-wrap gap-3">
                     <a href="/mypage/password" class="bg-gray-100 text-gray-700 px-4 py-2 rounded-button text-sm hover:bg-gray-200 transition">비밀번호 변경</a>
+                    <a href="/mypage/instructor-check" class="bg-blue-100 text-blue-700 px-4 py-2 rounded-button text-sm hover:bg-blue-200 transition">
+                        <span th:if="${isInstructor}">강사 페이지</span>
+                        <span th:unless="${isInstructor}">강사 인증</span>
+                    </a>
                 </div>
             </div>
         </div>
@@ -228,9 +232,9 @@
             </div>
             <div>
                 <h4 class="text-lg font-bold mb-4">연락처</h4>
-                <p class="text-gray-400">대전광역시 유성구 엑스포로 123</p>
-                <p class="text-gray-400">이메일: info@gamecoaching.com</p>
-                <p class="text-gray-400">전화: 042-123-4567</p>
+                <p class="text-gray-400">서울특별시 강남구 포레스트로 123</p>
+                <p class="text-gray-400">이메일: 4rest@reboot.com</p>
+                <p class="text-gray-400">전화: 123-456-7890</p>
             </div>
         </div>
         <div class="border-t border-gray-700 mt-8 pt-8 text-center text-gray-400">

--- a/src/main/resources/templates/mypage/index.html
+++ b/src/main/resources/templates/mypage/index.html
@@ -25,21 +25,40 @@
 </head>
 <body>
 <!-- 헤더 -->
-<header class="bg-white shadow">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
-        <a href="/" class="text-2xl font-['Pacifico'] text-primary">Re:Boot</a>
-        <nav>
-            <ul class="flex space-x-4">
-                <li><a href="/" class="text-gray-600 hover:text-primary">홈</a></li>
-                <li><a href="/lectures" class="text-gray-600 hover:text-primary">강의</a></li>
-                <li><a href="/mypage" class="text-primary font-bold">마이페이지</a></li>
-                <li>
-                    <form id="logoutForm" action="/logout" method="post" class="inline">
-                        <button type="submit" class="text-gray-600 hover:text-primary bg-transparent border-0 cursor-pointer">로그아웃</button>
-                    </form>
-                </li>
-            </ul>
-        </nav>
+<header class="bg-white shadow-sm sticky top-0 z-50">
+    <div class="container mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center">
+            <a href="/" class="text-2xl font-['Pacifico'] text-primary mr-10">Re:Boot</a>
+            <nav class="hidden md:flex space-x-8">
+                <a href="/lectures" class="text-gray-800 hover:text-primary font-medium">강의</a>
+                <a href="/replays/upload" class="text-gray-800 hover:text-primary font-medium">리플레이</a>
+                <a href="/mypage" class="text-gray-800 hover:text-primary font-medium">마이페이지</a>
+            </nav>
+        </div>
+
+        <div class="flex items-center space-x-4">
+            <div class="relative hidden md:block">
+                <form action="/lectures/search" method="GET">
+                    <div class="relative">
+                        <input type="text" name="keyword" placeholder="게임, 강의 검색" class="pl-10 pr-4 py-2 border border-gray-300 rounded-full text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent w-64">
+                        <button type="submit" class="absolute left-3 top-2.5 w-5 h-5 flex items-center justify-center text-gray-400 hover:text-primary">
+                            <i class="ri-search-line"></i>
+                        </button>
+                    </div>
+                </form>
+            </div>
+
+            <!-- 기존 로그아웃 형태 유지 -->
+            <div class="flex items-center space-x-4">
+                <form id="logoutForm" action="/logout" method="post" class="inline">
+                    <button type="submit" class="text-gray-600 hover:text-primary bg-transparent border-0 cursor-pointer">로그아웃</button>
+                </form>
+            </div>
+
+            <button class="md:hidden w-10 h-10 flex items-center justify-center">
+                <i class="ri-menu-line text-xl"></i>
+            </button>
+        </div>
     </div>
 </header>
 

--- a/src/main/resources/templates/mypage/index.html
+++ b/src/main/resources/templates/mypage/index.html
@@ -110,54 +110,105 @@
         </div>
     </div>
 
-    <!-- 예약 내역 섹션 -->
-    <div class="bg-white rounded-lg shadow p-6">
+    <!-- 결제 완료된 강의 섹션 -->
+    <div class="bg-white rounded-lg shadow p-6 mb-8">
         <div class="flex justify-between items-center mb-6">
-            <h3 class="text-xl font-bold">수강 내역</h3>
-            <a href="/mypage/reservationMIES" class="text-primary text-sm hover:underline">전체 내역 보기</a>
+            <h3 class="text-xl font-bold">수강 목록</h3>
         </div>
 
-        <div th:if="${#lists.isEmpty(reservationMIES)}" class="text-center py-8">
-            <p class="text-gray-500">예약 내역이 없습니다.</p>
-            <a href="/lectures" class="inline-block mt-4 bg-secondary text-white px-4 py-2 rounded-button text-sm hover:bg-green-700 transition">강의 찾아보기</a>
+        <div th:if="${#lists.isEmpty(completedPayments)}" class="text-center py-8">
+            <p class="text-gray-500">수강 강의가 없습니다.</p>
+            <a href="/lectures" class="inline-block mt-4 bg-primary text-white px-4 py-2 rounded-button text-sm hover:bg-indigo-700 transition">강의 찾아보기</a>
         </div>
 
-        <div th:unless="${#lists.isEmpty(reservationMIES)}" class="overflow-x-auto">
+        <div th:unless="${#lists.isEmpty(completedPayments)}" class="overflow-x-auto">
             <table class="min-w-full divide-y divide-gray-200">
                 <thead class="bg-gray-50">
                 <tr>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">강의명</th>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">코치</th>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">수강 날짜</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">강사</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">수강 일정</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">결제 금액</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">결제일</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">상태</th>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">상세</th>
                 </tr>
                 </thead>
                 <tbody class="bg-white divide-y divide-gray-200">
-                <tr th:each="reservation : ${reservationMIES}">
+                <tr th:each="payment : ${completedPayments}">
                     <td class="px-6 py-4 whitespace-nowrap">
-                        <div class="text-sm font-medium text-gray-900" th:text="${reservation.lectureName}">게임 실력 향상 코칭</div>
+                        <div class="text-sm font-medium text-gray-900" th:text="${payment.reservation.lecture.info.title}">강의명</div>
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap">
-                        <div class="text-sm text-gray-900" th:text="${reservation.instructorName}">김코치</div>
+                        <div class="text-sm text-gray-900" th:text="${payment.reservation.instructor.member.name}">강사명</div>
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap">
-                        <div class="text-sm text-gray-900" th:text="${#temporals.format(reservation.date, 'yyyy-MM-dd HH:mm')}">2023-05-10 14:00</div>
+                        <div class="text-sm text-gray-900" th:text="${payment.reservation.scheduleDate}">수강일정</div>
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap">
-                        <span th:if="${reservation.status == 'COMPLETED'}" class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">완료</span>
-                        <span th:if="${reservation.status == 'PENDING'}" class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">예약중</span>
-                        <span th:if="${reservation.status == 'CANCELED'}" class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">취소</span>
+                        <div class="text-sm text-gray-900" th:text="${#numbers.formatInteger(payment.price, 3, 'COMMA')} + '원'">결제금액</div>
                     </td>
-                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        <a th:href="@{/mypage/reservationMIES/{id}(id=${reservation.id})}" class="text-primary hover:underline">상세보기</a>
+                    <td class="px-6 py-4 whitespace-nowrap">
+                        <div class="text-sm text-gray-900" th:text="${#temporals.format(payment.paymentAt, 'yyyy-MM-dd HH:mm')}">결제일</div>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap">
+                        <span th:if="${payment.status == '결제완료'}" class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">결제완료</span>
+                        <span th:if="${payment.status == '결제 대기'}" class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">결제 대기</span>
+                        <span th:if="${payment.status == '환불 완료'}" class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">환불 완료</span>
                     </td>
                 </tr>
                 </tbody>
             </table>
         </div>
     </div>
-</main>
+
+<!--    &lt;!&ndash; 예약 내역 섹션 &ndash;&gt;-->
+<!--    <div class="bg-white rounded-lg shadow p-6">-->
+<!--        <div class="flex justify-between items-center mb-6">-->
+<!--            <h3 class="text-xl font-bold">수강 내역</h3>-->
+<!--            <a href="/mypage/reservationMIES" class="text-primary text-sm hover:underline">전체 내역 보기</a>-->
+<!--        </div>-->
+
+<!--        <div th:if="${#lists.isEmpty(reservationMIES)}" class="text-center py-8">-->
+<!--            <p class="text-gray-500">예약 내역이 없습니다.</p>-->
+<!--            <a href="/lectures" class="inline-block mt-4 bg-secondary text-white px-4 py-2 rounded-button text-sm hover:bg-green-700 transition">강의 찾아보기</a>-->
+<!--        </div>-->
+
+<!--        <div th:unless="${#lists.isEmpty(reservationMIES)}" class="overflow-x-auto">-->
+<!--            <table class="min-w-full divide-y divide-gray-200">-->
+<!--                <thead class="bg-gray-50">-->
+<!--                <tr>-->
+<!--                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">강의명</th>-->
+<!--                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">코치</th>-->
+<!--                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">수강 날짜</th>-->
+<!--                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">상태</th>-->
+<!--                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">상세</th>-->
+<!--                </tr>-->
+<!--                </thead>-->
+<!--                <tbody class="bg-white divide-y divide-gray-200">-->
+<!--                <tr th:each="reservation : ${reservationMIES}">-->
+<!--                    <td class="px-6 py-4 whitespace-nowrap">-->
+<!--                        <div class="text-sm font-medium text-gray-900" th:text="${reservation.lectureName}">게임 실력 향상 코칭</div>-->
+<!--                    </td>-->
+<!--                    <td class="px-6 py-4 whitespace-nowrap">-->
+<!--                        <div class="text-sm text-gray-900" th:text="${reservation.instructorName}">김코치</div>-->
+<!--                    </td>-->
+<!--                    <td class="px-6 py-4 whitespace-nowrap">-->
+<!--                        <div class="text-sm text-gray-900" th:text="${#temporals.format(reservation.date, 'yyyy-MM-dd HH:mm')}">2023-05-10 14:00</div>-->
+<!--                    </td>-->
+<!--                    <td class="px-6 py-4 whitespace-nowrap">-->
+<!--                        <span th:if="${reservation.status == 'COMPLETED'}" class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">완료</span>-->
+<!--                        <span th:if="${reservation.status == 'PENDING'}" class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">예약중</span>-->
+<!--                        <span th:if="${reservation.status == 'CANCELED'}" class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">취소</span>-->
+<!--                    </td>-->
+<!--                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">-->
+<!--                        <a th:href="@{/mypage/reservationMIES/{id}(id=${reservation.id})}" class="text-primary hover:underline">상세보기</a>-->
+<!--                    </td>-->
+<!--                </tr>-->
+<!--                </tbody>-->
+<!--            </table>-->
+<!--        </div>-->
+<!--    </div>-->
+<!--</main>-->
 
 <!-- 푸터 -->
 <footer class="bg-gray-800 text-white py-8 mt-12">

--- a/src/main/resources/templates/mypage/index.html
+++ b/src/main/resources/templates/mypage/index.html
@@ -78,10 +78,6 @@
 
                 <div class="mt-6 flex flex-wrap gap-3">
                     <a href="/mypage/password" class="bg-gray-100 text-gray-700 px-4 py-2 rounded-button text-sm hover:bg-gray-200 transition">비밀번호 변경</a>
-                    <a href="/mypage/instructor-check" class="bg-blue-100 text-blue-700 px-4 py-2 rounded-button text-sm hover:bg-blue-200 transition">
-                        <span th:if="${isInstructor}">강사 페이지</span>
-                        <span th:unless="${isInstructor}">강사 인증</span>
-                    </a>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/mypage/instructorMypage.html
+++ b/src/main/resources/templates/mypage/instructorMypage.html
@@ -32,7 +32,7 @@
                 <li><a href="/" class="text-gray-600 hover:text-primary">홈</a></li>
                 <li><a href="/lectures" class="text-gray-600 hover:text-primary">강의</a></li>
                 <li><a href="/mypage" class="text-gray-600 hover:text-primary">마이페이지</a></li>
-                <li><a href="/instructor/mypage" class="text-primary font-bold">강사 페이지</a></li>
+                <li><a href="/mypage/instructorMypage" class="text-primary font-bold">강사 페이지</a></li>
                 <li>
                     <form id="logoutForm" action="/logout" method="post" class="inline">
                         <button type="submit" class="text-gray-600 hover:text-primary bg-transparent border-0 cursor-pointer">로그아웃</button>

--- a/src/main/resources/templates/mypage/instructorMypage.html
+++ b/src/main/resources/templates/mypage/instructorMypage.html
@@ -9,6 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap" rel="stylesheet">
     <style>
         body {
             font-family: 'Noto Sans KR', sans-serif;
@@ -26,13 +27,12 @@
 <!-- 헤더 (기존 마이페이지와 동일) -->
 <header class="bg-white shadow">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
-        <h1 class="text-2xl font-bold text-gray-800">게임 코칭 매칭 플랫폼</h1>
+        <a href="/" class="text-2xl font-['Pacifico'] text-primary">Re:Boot</a>
         <nav>
             <ul class="flex space-x-4">
                 <li><a href="/" class="text-gray-600 hover:text-primary">홈</a></li>
                 <li><a href="/lectures" class="text-gray-600 hover:text-primary">강의</a></li>
-                <li><a href="/mypage" class="text-gray-600 hover:text-primary">마이페이지</a></li>
-                <li><a href="/mypage/instructorMypage" class="text-primary font-bold">강사 페이지</a></li>
+                <li><a href="/mypage" class="text-primary font-bold">마이페이지</a></li>
                 <li>
                     <form id="logoutForm" action="/logout" method="post" class="inline">
                         <button type="submit" class="text-gray-600 hover:text-primary bg-transparent border-0 cursor-pointer">로그아웃</button>

--- a/src/main/resources/templates/mypage/instructorMypage.html
+++ b/src/main/resources/templates/mypage/instructorMypage.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>강사 마이페이지 - 게임 코칭 매칭 플랫폼</title>
+    <script src="https://cdn.tailwindcss.com/3.4.16"></script>
+    <script>tailwind.config={theme:{extend:{colors:{primary:'#4F46E5',secondary:'#10B981'},borderRadius:{'none':'0px','sm':'4px',DEFAULT:'8px','md':'12px','lg':'16px','xl':'20px','2xl':'24px','3xl':'32px','full':'9999px','button':'8px'}}}}</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Noto Sans KR', sans-serif;
+            background-color: #f5f5f7;
+        }
+        .profile-image {
+            width: 120px;
+            height: 120px;
+            border-radius: 50%;
+            object-fit: cover;
+        }
+    </style>
+</head>
+<body>
+<!-- 헤더 (기존 마이페이지와 동일) -->
+<header class="bg-white shadow">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
+        <h1 class="text-2xl font-bold text-gray-800">게임 코칭 매칭 플랫폼</h1>
+        <nav>
+            <ul class="flex space-x-4">
+                <li><a href="/" class="text-gray-600 hover:text-primary">홈</a></li>
+                <li><a href="/lectures" class="text-gray-600 hover:text-primary">강의</a></li>
+                <li><a href="/mypage" class="text-gray-600 hover:text-primary">마이페이지</a></li>
+                <li><a href="/instructor/mypage" class="text-primary font-bold">강사 페이지</a></li>
+                <li>
+                    <form id="logoutForm" action="/logout" method="post" class="inline">
+                        <button type="submit" class="text-gray-600 hover:text-primary bg-transparent border-0 cursor-pointer">로그아웃</button>
+                    </form>
+                </li>
+            </ul>
+        </nav>
+    </div>
+</header>
+
+<main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <!-- 강사 프로필 정보 -->
+    <div class="bg-white rounded-lg shadow p-6 mb-8">
+        <div class="flex flex-col md:flex-row items-center md:items-start gap-8">
+            <!-- 프로필 이미지 -->
+            <div class="flex flex-col items-center">
+                <img th:if="${member.profileImage}" th:src="${member.profileImage}" alt="프로필 이미지" class="profile-image mb-4">
+                <img th:unless="${member.profileImage}" src="/images/default-profile.png" alt="기본 프로필 이미지" class="profile-image mb-4">
+                <a href="/instructor/mypage/profile" class="bg-primary text-white px-4 py-2 rounded-button text-sm hover:bg-indigo-700 transition">프로필 수정</a>
+            </div>
+
+            <!-- 강사 정보 -->
+            <div class="flex-1">
+                <h2 class="text-2xl font-bold mb-4 text-blue-600">강사 프로필</h2>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                        <p class="text-gray-500 text-sm">이름</p>
+                        <p class="font-medium" th:text="${member.name}">홍길동</p>
+                    </div>
+                    <div>
+                        <p class="text-gray-500 text-sm">닉네임</p>
+                        <p class="font-medium" th:text="${member.nickname}">강사닉네임</p>
+                    </div>
+                    <div>
+                        <p class="text-gray-500 text-sm">평점</p>
+                        <p class="font-medium" th:text="${instructor.averageRating}">4.5</p>
+                    </div>
+                    <div>
+                        <p class="text-gray-500 text-sm">총 수강생 수</p>
+                        <p class="font-medium" th:text="${instructor.totalMembers}">24명</p>
+                    </div>
+                </div>
+
+                <!-- description -->
+                <div class="mt-6">
+                    <p class="text-gray-500 text-sm">경력</p>
+                    <p class="font-medium" th:text="${instructor.career}">5년 경력의 다이아몬드 랭크 강사입니다.</p>
+                </div>
+
+                <!-- 소개글 -->
+                <div class="mt-4">
+                    <p class="text-gray-500 text-sm">소개글</p>
+                    <p class="font-medium" th:text="${instructor.description}">게임 실력 향상을 위한 맞춤형 코칭을 제공합니다.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- 내 강의 목록 -->
+    <div class="bg-white rounded-lg shadow p-6 mb-8">
+        <div class="flex justify-between items-center mb-6">
+            <h3 class="text-xl font-bold">내가 등록한 강의</h3>
+            <a href="/instructor/lectures/register" class="bg-primary text-white px-4 py-2 rounded-button text-sm hover:bg-indigo-700 transition">새 강의 등록</a>
+        </div>
+
+        <!-- 강의 목록 표시 예정 -->
+        <div class="text-center py-8">
+            <p class="text-gray-500">등록된 강의가 없습니다.</p>
+        </div>
+    </div>
+
+    <!-- 수강생 관리 -->
+    <div class="bg-white rounded-lg shadow p-6">
+        <div class="flex justify-between items-center mb-6">
+            <h3 class="text-xl font-bold">수강생 관리</h3>
+        </div>
+
+        <!-- 수강생 목록 표시 예정 -->
+        <div class="text-center py-8">
+            <p class="text-gray-500">수강생이 없습니다.</p>
+        </div>
+    </div>
+</main>
+
+<!-- 푸터 (기존 마이페이지와 동일) -->
+<footer class="bg-gray-800 text-white py-8 mt-12">
+    <!-- 푸터 내용 -->
+</footer>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        console.log('강사 마이페이지가 로드되었습니다.');
+    });
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/mypage/instructorMypage.html
+++ b/src/main/resources/templates/mypage/instructorMypage.html
@@ -24,22 +24,41 @@
     </style>
 </head>
 <body>
-<!-- 헤더 (기존 마이페이지와 동일) -->
-<header class="bg-white shadow">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
-        <a href="/" class="text-2xl font-['Pacifico'] text-primary">Re:Boot</a>
-        <nav>
-            <ul class="flex space-x-4">
-                <li><a href="/" class="text-gray-600 hover:text-primary">홈</a></li>
-                <li><a href="/lectures" class="text-gray-600 hover:text-primary">강의</a></li>
-                <li><a href="/mypage" class="text-primary font-bold">마이페이지</a></li>
-                <li>
-                    <form id="logoutForm" action="/logout" method="post" class="inline">
-                        <button type="submit" class="text-gray-600 hover:text-primary bg-transparent border-0 cursor-pointer">로그아웃</button>
-                    </form>
-                </li>
-            </ul>
-        </nav>
+<!-- 헤더 -->
+<header class="bg-white shadow-sm sticky top-0 z-50">
+    <div class="container mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center">
+            <a href="/" class="text-2xl font-['Pacifico'] text-primary mr-10">Re:Boot</a>
+            <nav class="hidden md:flex space-x-8">
+                <a href="/lectures" class="text-gray-800 hover:text-primary font-medium">강의</a>
+                <a href="/replays/upload" class="text-gray-800 hover:text-primary font-medium">리플레이</a>
+                <a href="/mypage" class="text-gray-800 hover:text-primary font-medium">마이페이지</a>
+            </nav>
+        </div>
+
+        <div class="flex items-center space-x-4">
+            <div class="relative hidden md:block">
+                <form action="/lectures/search" method="GET">
+                    <div class="relative">
+                        <input type="text" name="keyword" placeholder="게임, 강의 검색" class="pl-10 pr-4 py-2 border border-gray-300 rounded-full text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent w-64">
+                        <button type="submit" class="absolute left-3 top-2.5 w-5 h-5 flex items-center justify-center text-gray-400 hover:text-primary">
+                            <i class="ri-search-line"></i>
+                        </button>
+                    </div>
+                </form>
+            </div>
+
+            <!-- 기존 로그아웃 형태 유지 -->
+            <div class="flex items-center space-x-4">
+                <form id="logoutForm" action="/logout" method="post" class="inline">
+                    <button type="submit" class="text-gray-600 hover:text-primary bg-transparent border-0 cursor-pointer">로그아웃</button>
+                </form>
+            </div>
+
+            <button class="md:hidden w-10 h-10 flex items-center justify-center">
+                <i class="ri-menu-line text-xl"></i>
+            </button>
+        </div>
     </div>
 </header>
 


### PR DESCRIPTION
## PR 메시지 (강사 마이페이지 구현)

### 🎯 기능 개요
회원가입 시 설정된 role(USER/INSTRUCTOR)에 따라 마이페이지 자동 분기 구현

### ✨ 구현 내용

#### 1. 강사 마이페이지 구조 구현
- `InstructorMyPageController` 신규 생성 (`/mypage/instructorMypage`)
- `InstructorMyPageService` 신규 생성
- 강사 전용 템플릿 `mypage/instructorMypage.html` 작성

#### 2. 자동 분기 로직 구현
- 일반 마이페이지(`/mypage`) 접속 시 role 기반 자동 분기
  - USER: 일반 마이페이지 표시
  - INSTRUCTOR: 강사 마이페이지로 리다이렉트
- 일반 회원이 강사 페이지 직접 접근 시 일반 마이페이지로 리다이렉트

#### 3. 서비스 개선
- `MypageService`에 `isInstructor()` 메서드 추가
- `InstructorMyPageService`에 강사 인증 및 정보 조회 메서드 구현
- `InstructorRepository`에 Member 기반 조회 메서드 추가
  - `existsByMember(Member member)`
  - `findByMember(Member member)`

#### 4. 기존 기능 정리
- 마이페이지의 '강사 페이지' 버튼 제거 (자동 분기로 대체)
- `/instructor-check` 라우트 제거
- 네비게이션 구조 정리

### 📁 파일 변경 사항

**신규 파일**
- `InstructorMyPageController.java`
- `InstructorMyPageService.java`
- `mypage/instructorMypage.html`

**수정 파일**
- `MypageController.java` - 자동 분기 로직 추가
- `MypageService.java` - isInstructor() 메서드 추가
- `mypage/index.html` - 강사 페이지 버튼 제거